### PR TITLE
[WebProfilerBundle ] Removes the ajax animation in sf-toolbar-block-ajax

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -179,7 +179,10 @@
                 var className = 'sf-toolbar-ajax-requests sf-toolbar-value';
                 requestCounter[0].className = className;
 
-                if (state == 'error') {
+                if (state == 'ok') {
+                    Sfjs.removeClass(ajaxToolbarPanel, 'sf-ajax-request-loading');
+                    Sfjs.removeClass(ajaxToolbarPanel, 'sf-toolbar-status-red');
+                } else if (state == 'error') {
                     Sfjs.addClass(ajaxToolbarPanel, 'sf-toolbar-status-red');
                 } else {
                     Sfjs.addClass(ajaxToolbarPanel, 'sf-ajax-request-loading');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | n/a |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

The change removes the animation in the "sf-toolbar-block-ajax" when the request state was "ok".
